### PR TITLE
Fix ghost and actual defender sizing issues

### DIFF
--- a/defenders.js
+++ b/defenders.js
@@ -168,16 +168,22 @@ let tooltipTimer = 0;
 let displayTooltip = false;
 let currentHover;
 function drawGhost(gridCell) {
+  const gridPositionX = gridCell.x + cellGap,
+    gridPositionY = gridCell.y + cellGap;
   if (
     buildDefender &&
     collision(gridCell, mouse) &&
-    !doesDefenderOccupySpace(gridCell.x + cellGap, gridCell.y + cellGap)
+    !doesDefenderOccupySpace(gridPositionX, gridPositionY)
   ) {
     ctx.globalAlpha = 0.4;
     ctx.drawImage(
       defenderSpriteTypes[globalChosenDefender],
-      gridCell.x + 10,
-      gridCell.y,
+      0,
+      0,
+      164,
+      195,
+      gridPositionX + 10,
+      gridPositionY,
       cellSize - cellGap * 2 - 20,
       cellSize - cellGap * 2
     );


### PR DESCRIPTION
Similar to #32 where the `gridcell` coordinates were not including `cellGap` so were off by 3 pixels in the x and y direction compraed to the actual defender placing. The source image used in the class uses specific source coordinates whilst the one in `drawGhost` was taking the whole source image, this also led to a few pixels variation in display between the two.